### PR TITLE
Add acceptableRemoteVersions

### DIFF
--- a/src/main/java/com/mr208/dirt2path/Dirt2Path.java
+++ b/src/main/java/com/mr208/dirt2path/Dirt2Path.java
@@ -30,7 +30,7 @@ import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
-@Mod(modid = Dirt2Path.MOD_ID, name = Dirt2Path.MOD_NAME, version = "1.6.2", acceptedMinecraftVersions = "[1.9,1.12)")
+@Mod(modid = Dirt2Path.MOD_ID, name = Dirt2Path.MOD_NAME, version = "1.6.2", acceptedMinecraftVersions = "[1.9,1.12)", acceptableRemoteVersions = "*")
 public class Dirt2Path {
 
 	public static final String MOD_ID = "dirt2path";


### PR DESCRIPTION
This should allow Dirt2Path to be installed on servers without clients needing it to connect.